### PR TITLE
fix missing link

### DIFF
--- a/components/ServiceList/index.js
+++ b/components/ServiceList/index.js
@@ -37,15 +37,17 @@ export default function ServiceList() {
       <Link href="/create">+ add service</Link>
       <ul>
         {services.map((service) => (
-          <li key={service._id}>
-            <Image
-              src={service.image}
-              width={100}
-              height={100}
-              alt={`picture of the ${service.name}`}
-            />
-            {service.name}
-          </li>
+          <Link key={service._id} href={`/${service._id}`}>
+            <li>
+              <Image
+                src={service.image}
+                width={100}
+                height={100}
+                alt={`picture of the ${service.name}`}
+              />
+              {service.name}
+            </li>
+          </Link>
         ))}
       </ul>
     </>


### PR DESCRIPTION
after merging user stories 3 and 4, a line of code which provided a link from each list element to that element's detail page was missing. We opened a debug branch, rewrote the missing line of code and merged.